### PR TITLE
Add our signal-related monkeypatch, now that we have a forked version of this repo

### DIFF
--- a/background_task/utils.py
+++ b/background_task/utils.py
@@ -18,6 +18,13 @@ class SignalManager(object):
             signal.signal(signal.SIGTERM, self.exit_gracefully)
         else:
             signal.signal(signal.SIGTSTP, self.exit_gracefully)
+
+            # A Deck-specific tweak...
+            # We want it to handle SIGTERM like it handles SIGTSTP, and do a graceful shutdown
+            # where it finishes any in-progress tasks, but doesn't grab any new ones.
+            # This allows for graceful shutdowns during Kubernetes redeployments.
+            signal.signal(signal.SIGTERM, self.exit_gracefully)
+
             signal.signal(signal.SIGUSR1, self.speed_up)
             signal.signal(signal.SIGUSR2, self.slow_down)
 


### PR DESCRIPTION
I added a monkeypatch to this repo in https://github.com/decktools/deck/pull/1627. But now we can just modify the relevant code directly.

Once this is in, I'll remove the monkeypatch in the deck repo.